### PR TITLE
Change targetPort of back Service

### DIFF
--- a/source/administration/deployment.rst
+++ b/source/administration/deployment.rst
@@ -87,7 +87,7 @@ Now, create a Service to expose the backend::
         ports:
           - protocol: TCP
             port: 5000
-            targetPort: http
+            targetPort: 5000
 
 Now you can add a Service and an Ingress to expose the web server on the
 network::

--- a/source/files/deployment.yaml
+++ b/source/files/deployment.yaml
@@ -56,7 +56,7 @@ spec:
     ports:
       - protocol: TCP
         port: 5000
-        targetPort: http
+        targetPort: 5000
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
targetPort was http aka 80. But we want the service back to route port-5000-traffic it receives on port 5000 of its (back) pods